### PR TITLE
Add zsh-history-substring-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Colors: `#282C34`, `#E06C75`, `#98C379`, `#E5C07B`, `#61AFEF`, `#C678DD`, `#56B6
 - Oh-My-Zsh ([web link](https://github.com/ohmyzsh/ohmyzsh))
 - VimPlug (install for Vim & NeoVim) ([web link](https://github.com/junegunn/vim-plug))
 - PowerLevel9K (follow oh-my-zsh install) ([web link](https://github.com/Powerlevel9k/powerlevel9k/wiki/Install-Instructions#option-2-install-for-oh-my-zsh))
+- zsh-history-substring-search (follow oh-my-zsh install) ([web link](https://github.com/zsh-users/zsh-history-substring-search))
 - Done
 
 ### Step Two: Brew Installations

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ echo "This install script will check for and install Homebrew, in addition to th
 echo "[1] Zsh [2] Coreutils [3] Neovim [4] Git [5] Tmux [6] Fzf [7] Ripgrep [8] Bat"
 echo "After the required brews are installed, optional brews will be installed with (y/n) user prompts."
 echo
-echo "The install script will then check for and install Oh-My-Zsh, PowerLevel9K, VimPlug, and finally Xavier Config"
+echo "The install script will then check for and install Oh-My-Zsh, PowerLevel9K, zsh-history-substring-search, VimPlug, and finally Xavier Config"
 echo "After the install is complete, the Xavier Config directory will exist at ~/.xavier-config."
 echo
 echo "Any prior .zshrc .tmux.conf or init.vim files are backed up during the install process to a timestamped backup"
@@ -156,6 +156,17 @@ if dir_exists $powerlevel9k_dir; then
 else
     echo "${yellow}$step: PowerLevel9K not detected, cloning PowerLevel9K...${normal}"
     git clone https://github.com/bhilburn/powerlevel9k.git $powerlevel9k_dir
+fi
+
+# HISTORY-SUBSTRING-SEARCH INSTALL
+
+((step++))
+history_substring_search_dir="${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-history-substring-search}"
+if ! dir_exists $history_substring_search_dir; then
+    echo "${yellow}$step: history-substring-search repo not detected in Oh-My-Zsh plugin directory, cloning...${normal}"
+    git clone https://github.com/zsh-users/zsh-history-substring-search $history_substring_search_dir
+else
+    echo "${blue}$step: history-substring-search repo found in Oh-My-Zsh plugin directory, skipping install.${normal}"
 fi
 
 # VIM PLUG INSTALL

--- a/zsh/.zshrc-example
+++ b/zsh/.zshrc-example
@@ -9,6 +9,7 @@ fi
 plugins=(
     git
     tmux
+    vi-mode
 )
 
 # Path to your oh-my-zsh installation.

--- a/zsh/.zshrc-example
+++ b/zsh/.zshrc-example
@@ -9,7 +9,7 @@ fi
 plugins=(
     git
     tmux
-    vi-mode
+    history-substring-search
 )
 
 # Path to your oh-my-zsh installation.


### PR DESCRIPTION
This adds [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) as an oh-my-zsh plugin for default installation.

(The first commit can be ignored, I removed the addition of vi-mode so that it could be done in a separate PR if necessary).

